### PR TITLE
[Bugfix] Set nonce using `setAttribute`

### DIFF
--- a/projects/ngx-google-analytics/src/lib/initializers/google-analytics.initializer.ts
+++ b/projects/ngx-google-analytics/src/lib/initializers/google-analytics.initializer.ts
@@ -72,7 +72,7 @@ export function GoogleAnalyticsInitializer(
     s.src = settings.uri;
 
     if (settings.nonce) {
-      s.nonce = settings.nonce;
+      s.setAttribute('nonce', settings.nonce);
     }
 
     const head: HTMLHeadElement = document.getElementsByTagName('head')[0];


### PR DESCRIPTION
Unfortunately, setting `nonce` on the script using `s.nonce = 'VALUE'` does not actually add the `nonce` to the script.

Instead, you have to use `setAttribute`: `s.setAttribute('nonce', 'VALUE')`.

I have tested and verified this functionality locally.