### PR TITLE
Exporting enum

### DIFF
--- a/projects/ngx-google-analytics/src/public_api.ts
+++ b/projects/ngx-google-analytics/src/public_api.ts
@@ -6,6 +6,8 @@ export * from './lib/directives/ga-event-category.directive';
 export * from './lib/directives/ga-event.directive';
 export * from './lib/directives/ga-event-form-input.directive';
 
+export * from './lib/enums/ga-action.enum';
+
 export * from './lib/initializers/google-analytics.initializer';
 export * from './lib/initializers/google-analytics-router.initializer';
 


### PR DESCRIPTION
Exporting the newly included enum for the public API.

I didn't know it worked like this, now it says: Can't resolve 'ngx-google
-analytics/lib/enums/ga-action.enum'