### PR TITLE
Fix module commands usage

### DIFF
--- a/projects/ngx-google-analytics/src/lib/initializers/google-analytics.initializer.ts
+++ b/projects/ngx-google-analytics/src/lib/initializers/google-analytics.initializer.ts
@@ -61,7 +61,7 @@ export function GoogleAnalyticsInitializer(
       { command: 'config', values: [ settings.trackingCode ] }
     ];
 
-    settings.initCommands = [ ...initialCommands, ...(settings.initCommands || []) ];
+    settings.initCommands = [ ...initialCommands, ...(settings.commands || []) ];
 
     for (const command of settings.initCommands) {
       gtag(command.command, ...command.values);


### PR DESCRIPTION
The commands provided in the app.module are never used due to a bug in the initializer